### PR TITLE
fix relay mutation file upload with auth middleware fix

### DIFF
--- a/src/relay/mutation.js
+++ b/src/relay/mutation.js
@@ -42,6 +42,7 @@ function _hasFiles(relayRequest) {
 function _mutationWithFiles(relayRequest) {
   const req = {
     method: 'POST',
+    headers: {}
   };
 
   if (_hasFiles(relayRequest)) {


### PR DESCRIPTION
When using Relay's getFiles() in a mutation, combined with the auth middleware throws an error.

```
export default function authMiddleware(opts = {}) {
  const { token: tokenOrThunk, tokenRefreshPromise, prefix = 'Bearer ' } = opts;

  return next => req => {
    return new Promise((resolve, reject) => {
      const token = isFunction(tokenOrThunk) ? tokenOrThunk(req) : tokenOrThunk;
      if (!token && tokenRefreshPromise) {
        reject(new WrongTokenError('Token not provided, try fetch new one'));
      }
      resolve(token);
    }).then(token => {
      req.headers['Authorization'] = `${prefix}${token}`; // Fails because req.headers hasn't been set yet
      return next(req);
    }).then(res => {
      if (res.status === 401 && tokenRefreshPromise) {
        throw new WrongTokenError('Was recieved status 401 from server', res);
      }
      return res;
    }).catch(err => {
      if (err.name === 'WrongTokenError') {
        return tokenRefreshPromise(req, err.res)
          .then(newToken => {
            req.headers['Authorization'] = `${prefix}${newToken}`;
            return next(req); // re-run query with new token
          });
      }

      throw err;
    });
  };
}
```

There might be a better way to handle this.