### PR TITLE
Handle malformed or non existent JSON in response

### DIFF
--- a/src/fetchWrapper.js
+++ b/src/fetchWrapper.js
@@ -21,6 +21,10 @@ export default function fetchWrapper(reqFromRelay, middlewares) {
             res.json = json;
             return res;
           })
+          .catch(e => {
+              res.json = {};
+              return res;
+          })
         )
         .then(res => resolve(res))
         .catch(error => reject(error));


### PR DESCRIPTION
Hi, we have a number of reasons why the `/graphql` endpoint when hit will actually return HTML/XML or something that isn't valid JSON. For instance, if the user is not authenticated then we return a 403 page, this happens at the Nginx level. 

At the moment that means that we get an error coming through the middleware as a SyntaxError. This can't be gracefully dealt with by middleware other than by trying to catch that - if (error.name === 'SyntaxError') - and aside from that being ugly it also means the status code is ignored.

In this PR I'm trying to address this by catching any parsing errors arising from res.json() and returning a plain object instead. This is so that the status code can be handled correctly by thrownOnServerError where it throws the whole response, so that we can deal with the response.status inside our app (and direct the user to log in again!).