### PR TITLE
Inconsistency with RelayDefaultNetworkLayer for non-200 errors

### DIFF
--- a/src/createRequestError.js
+++ b/src/createRequestError.js
@@ -1,9 +1,14 @@
 /* eslint-disable prefer-template */
 
+/*
+ * Adapted from
+ * https://github.com/facebook/relay/blob/8223d37b802b3890c8a387c47cba382d634f5c21/src/network-layer/default/RelayDefaultNetworkLayer.js#L199
+ */
+
 /**
  * Formats an error response from GraphQL server request.
  */
-export default function formatRequestErrors(request, errors) {
+function formatRequestErrors(request, errors) {
   const CONTEXT_BEFORE = 20;
   const CONTEXT_LENGTH = 60;
 
@@ -25,4 +30,17 @@ export default function formatRequestErrors(request, errors) {
       '';
     return prefix + message + locationMessage;
   }).join('\n');
+}
+
+export default function createRequestError(request, requestType, responseStatus, payload) {
+  const errorReason = typeof payload === 'object' ?
+    formatRequestErrors(request, payload.errors) :
+    `Server response had an error status: ${responseStatus}`;
+  const error = new Error(
+    `Server request for ${requestType} \`${request.getDebugName()}\` ` +
+    `failed for the following reasons:\n\n${errorReason}`
+  );
+  error.source = payload;
+  error.status = responseStatus;
+  return error;
 }

--- a/src/createRequestError.js
+++ b/src/createRequestError.js
@@ -33,11 +33,13 @@ function formatRequestErrors(request, errors) {
 }
 
 export default function createRequestError(request, requestType, responseStatus, payload) {
+  const debugName = Array.isArray(request) ?
+    request.map(req => req.getDebugName()).join(' ') : request.getDebugName();
   const errorReason = typeof payload === 'object' ?
     formatRequestErrors(request, payload.errors) :
     `Server response had an error status: ${responseStatus}`;
   const error = new Error(
-    `Server request for ${requestType} \`${request.getDebugName()}\` ` +
+    `Server request for ${requestType} \`${debugName}\` ` +
     `failed for the following reasons:\n\n${errorReason}`
   );
   error.source = payload;

--- a/src/middleware/gqErrors.js
+++ b/src/middleware/gqErrors.js
@@ -41,20 +41,24 @@ export default function gqErrorsMiddleware(opts = {}) {
     const query = `${req.relayReqType} ${req.relayReqId}`;
 
     return next(req).then(res => {
-      if (res.json) {
-        if (Array.isArray(res.json)) {
-          res.json.forEach(batchItem => {
-            if (batchItem.payload.errors) {
-              displayErrors(batchItem.payload.errors, { query, req, res });
+      return res.json()
+        .then(json => {
+          if (Array.isArray(json)) {
+            json.forEach(batchItem => {
+              if (batchItem.payload.errors) {
+                displayErrors(batchItem.payload.errors, { query, req, res });
+              }
+            });
+          } else {
+            if (json.errors) {
+              displayErrors(json.errors, { query, req, res });
             }
-          });
-        } else {
-          if (res.json.errors) {
-            displayErrors(res.json.errors, { query, req, res });
           }
-        }
-      }
-      return res;
+          return res;
+        })
+        .catch(() => {
+          return res;
+        });
     });
   };
 }

--- a/src/relay/_query.js
+++ b/src/relay/_query.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign, prefer-template */
 
-import formatRequestErrors from '../formatRequestErrors';
+import createRequestError from '../createRequestError';
 
 export function queryPre(relayRequest) {
   const req = {
@@ -26,12 +26,7 @@ export function queryPre(relayRequest) {
 export function queryPost(relayRequest, fetchPromise) {
   return fetchPromise.then(payload => {
     if (payload.hasOwnProperty('errors')) {
-      const error = new Error(
-        'Server request for query `' + relayRequest.getDebugName() + '` ' +
-        'failed for the following reasons:\n\n' +
-        formatRequestErrors(relayRequest, payload.errors)
-      );
-      error.source = payload;
+      const error = createRequestError(relayRequest, 'query', '200', payload);
       relayRequest.reject(error);
     } else if (!payload.hasOwnProperty('data')) {
       relayRequest.reject(new Error(

--- a/src/relay/mutation.js
+++ b/src/relay/mutation.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign, no-use-before-define, prefer-template */
 
-import formatRequestErrors from '../formatRequestErrors';
+import createRequestError from '../createRequestError';
 
 export default function mutation(relayRequest, fetchWithMiddleware) {
   const req = {
@@ -19,12 +19,7 @@ export default function mutation(relayRequest, fetchWithMiddleware) {
   return fetchWithMiddleware(req)
     .then(payload => {
       if (payload.hasOwnProperty('errors')) {
-        const error = new Error(
-          'Server request for mutation `' + relayRequest.getDebugName() + '` ' +
-          'failed for the following reasons:\n\n' +
-          formatRequestErrors(relayRequest, payload.errors)
-        );
-        error.source = payload;
+        const error = createRequestError(relayRequest, 'mutation', '200', payload);
         relayRequest.reject(error);
       } else {
         relayRequest.resolve({ response: payload.data });

--- a/test/batch.test.js
+++ b/test/batch.test.js
@@ -54,6 +54,7 @@ describe('Batch tests', () => {
     const req1 = mockReq(1);
     req1.reject = (err) => {
       assert(err instanceof Error, 'should be an error');
+      assert.equal(err.status, 200);
     };
     const req2 = mockReq(2);
     assert.isFulfilled(rnl.sendQueries([req1, req2]));

--- a/test/fetchWrapper.test.js
+++ b/test/fetchWrapper.test.js
@@ -1,0 +1,64 @@
+import { assert } from 'chai';
+import fetchMock from 'fetch-mock';
+import fetchWrapper from '../src/fetchWrapper';
+import { mockReq as mockRelayReq } from './testutils';
+
+function createMockReq() {
+  const relayRequest = mockRelayReq();
+  const req = {
+    relayReqId: relayRequest.getID(),
+    relayReqObj: relayRequest,
+    relayReqType: 'query',
+    method: 'POST',
+    headers: {
+      Accept: '*/*',
+      'Content-Type': 'application/json',
+    },
+  };
+
+  req.body = JSON.stringify({
+    query: relayRequest.getQueryString(),
+    variables: relayRequest.getVariables(),
+  });
+
+  return req;
+}
+
+function createMockMiddlware() {
+  return next => req => {
+    return next(req).then(res => {
+      return res.json()
+        .then(() => {
+          return res;
+        })
+        .catch(() => {
+          return res;
+        });
+    });
+  };
+}
+
+describe('fetchWrapper', () => {
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  describe('with no middleware', () => {
+    it('should make a successfull request', () => {
+      fetchMock.post('/graphql', { data: {} });
+      assert.isFulfilled(fetchWrapper(createMockReq(), []));
+    });
+  });
+
+  describe('with middlewares each consuming `response.json()`', () => {
+    const middlewares = [
+      createMockMiddlware(),
+      createMockMiddlware(),
+    ];
+
+    it('should make a successfull request', () => {
+      fetchMock.post('/graphql', { data: {} });
+      assert.isFulfilled(fetchWrapper(createMockReq(), middlewares));
+    });
+  });
+});

--- a/test/mutation.test.js
+++ b/test/mutation.test.js
@@ -1,0 +1,81 @@
+import { assert } from 'chai';
+import fetchMock from 'fetch-mock';
+import { RelayNetworkLayer } from '../src';
+import { mockReq } from './testutils';
+
+describe('Mutation tests', () => {
+  const middlewares = [];
+  const rnl = new RelayNetworkLayer(middlewares);
+
+  afterEach(() => {
+    fetchMock.restore();
+  });
+
+  it('should make a successfull mutation', () => {
+    fetchMock.post('/graphql', { data: {} });
+    assert.isFulfilled(rnl.sendMutation(mockReq()));
+  });
+
+  it('should fail correctly on network failure', () => {
+    fetchMock.mock({
+      matcher: '/graphql',
+      response: {
+        throws: new Error('Network connection error'),
+      },
+      method: 'POST',
+    });
+    assert.isRejected(rnl.sendMutation(mockReq()), /Network connection error/);
+  });
+
+  it('should handle error response', () => {
+    fetchMock.mock({
+      matcher: '/graphql',
+      response: {
+        status: 200,
+        body: {
+          errors: [
+            { location: 1, message: 'major error' },
+          ],
+        },
+      },
+      method: 'POST',
+    });
+
+    const req1 = mockReq(1);
+    req1.reject = (err) => {
+      assert(err instanceof Error, 'should be an error');
+    };
+
+    return rnl.sendMutation(req1);
+  });
+
+  it('should handle server non-2xx errors', () => {
+    fetchMock.mock({
+      matcher: '/graphql',
+
+      response: {
+        status: 500,
+        body: {
+          errors: [{
+            message: 'Something went completely wrong.',
+          }],
+        },
+      },
+      method: 'POST',
+    });
+
+    const req1 = mockReq(1);
+    req1.reject = (err) => {
+      assert(err instanceof Error, 'should be an error');
+      assert.equal(err.message, [
+        'Server request for mutation `debugname1` failed for the following reasons:',
+        '',
+        'Server response had an error status: 500',
+      ].join('\n'));
+      assert.equal(err.status, 500);
+      assert.equal(err.source, '{"errors":[{"message":"Something went completely wrong."}]}');
+    };
+
+    return rnl.sendMutation(req1);
+  });
+});

--- a/test/mutation.test.js
+++ b/test/mutation.test.js
@@ -44,6 +44,7 @@ describe('Mutation tests', () => {
     const req1 = mockReq(1);
     req1.reject = (err) => {
       assert(err instanceof Error, 'should be an error');
+      assert.equal(err.status, 200);
     };
 
     return rnl.sendMutation(req1);

--- a/test/queries.test.js
+++ b/test/queries.test.js
@@ -44,6 +44,7 @@ describe('Queries tests', () => {
     const req1 = mockReq(1);
     req1.reject = (err) => {
       assert(err instanceof Error, 'should be an error');
+      assert.equal(err.status, 200);
     };
 
     return rnl.sendQueries([req1]);

--- a/test/queries.test.js
+++ b/test/queries.test.js
@@ -48,4 +48,34 @@ describe('Queries tests', () => {
 
     return rnl.sendQueries([req1]);
   });
+
+  it('should handle server non-2xx errors', () => {
+    fetchMock.mock({
+      matcher: '/graphql',
+
+      response: {
+        status: 500,
+        body: {
+          errors: [{
+            message: 'Something went completely wrong.',
+          }],
+        },
+      },
+      method: 'POST',
+    });
+
+    const req1 = mockReq(1);
+    req1.reject = (err) => {
+      assert(err instanceof Error, 'should be an error');
+      assert.equal(err.message, [
+        'Server request for query `debugname1` failed for the following reasons:',
+        '',
+        'Server response had an error status: 500',
+      ].join('\n'));
+      assert.equal(err.status, 500);
+      assert.equal(err.source, '{"errors":[{"message":"Something went completely wrong."}]}');
+    };
+
+    return rnl.sendQueries([req1]);
+  });
 });


### PR DESCRIPTION
Hi there,

I came across a difference with `RelayDefaultNetworkLayer` when handling non-200 errors from the server.

The transaction error should always be an `Error` type but currently it's a fetch `Response` type for non-200 errors.
`RelayDefaultNetworkLayer` had itself this inconsistency until it was fixed in https://github.com/facebook/relay/commit/dcc97a431af719b71b62506ce8fe29b85158ef3e

This PR applies the same kind of fix.

Let me know what you think.