### PR TITLE
Fix potential error in formatRequestErrors

### DIFF
--- a/src/formatRequestErrors.js
+++ b/src/formatRequestErrors.js
@@ -19,7 +19,7 @@ export default function formatRequestErrors(request, errors) {
         const offset = Math.min(column - 1, CONTEXT_BEFORE);
         return [
           queryLine.substr(column - 1 - offset, CONTEXT_LENGTH),
-          `${' '.repeat(offset)}^^^`,
+          `${' '.repeat(Math.max(offset, 0))}^^^`,
         ].map(messageLine => indent + messageLine).join('\n');
       }).join('\n')) :
       '';


### PR DESCRIPTION
We're using [Absinthe](http://absinthe-graphql.org) as our Relay backend, and due to a limitation in the way it parses the incoming queries, the column for an error's locations is unavailable.  As a result, the error formatter errors due to the returned column being 0 (understandable, since that's not a valid column number). This change fixes that problem.