### PR TITLE
Configurable header name for auth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Available middlewares:
   - `tokenRefreshPromise`: - function(req, err) which must return promise with new token, called only if server returns 401 status code and this function is provided.
   - `allowEmptyToken` - allow made a request without Authorization header if token is empty (default: `false`).
   - `prefix` - prefix before token (default: `'Bearer '`).
+  - `header` - name of the HTTP header to pass the token in (default: `'Authorization'`).
   - If you use `auth` middleware with `retry`, `retry` must be used before `auth`. Eg. if token expired when retries apply, then `retry` can call `auth` middleware again.
 - **logger** - for logging requests and responses. Options:
   - `logger` - log function (default: `console.log.bind(console, '[RELAY-NETWORK]')`)

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -16,6 +16,7 @@ export default function authMiddleware(opts = {}) {
     tokenRefreshPromise,
     allowEmptyToken = false,
     prefix = 'Bearer ',
+    header = 'Authorization',
   } = opts;
 
   return next => req => {
@@ -27,7 +28,7 @@ export default function authMiddleware(opts = {}) {
       resolve(token);
     }).then(token => {
       if (token) {
-        req.headers['Authorization'] = `${prefix}${token}`;
+        req.headers[header] = `${prefix}${token}`;
       }
       return next(req);
     }).then(res => {
@@ -39,7 +40,7 @@ export default function authMiddleware(opts = {}) {
       if (err.name === 'WrongTokenError') {
         return tokenRefreshPromise(req, err.res)
           .then(newToken => {
-            req.headers['Authorization'] = `${prefix}${newToken}`;
+            req.headers[header] = `${prefix}${newToken}`;
             return next(req); // re-run query with new token
           });
       }


### PR DESCRIPTION
This lets you customize the header to send the auth token in. Default behavior remains unchanged.