### PR TITLE
Batching: adds support for maxBatchSize option

### DIFF
--- a/src/relayNetworkLayer.js
+++ b/src/relayNetworkLayer.js
@@ -33,7 +33,7 @@ export default class RelayNetworkLayer {
 
   sendQueries(requests) {
     if (requests.length > 1 && !this._isBatchQueriesDisabled()) {
-      return queriesBatch(requests, this._fetchWithMiddleware);
+      return queriesBatch(requests, this._fetchWithMiddleware, this._options);
     }
 
     return queries(requests, this._fetchWithMiddleware);


### PR DESCRIPTION
As discussed in #39 there are certain situations where a user
may want to limit the amount of requests sent to the batchUrl at once.

This PR changes the batched request workflow so that if maxBatchSize is
provided it will chunk out the batched requests into numerous requests,
the flatten the responses into a single array and resolve them the same
way relay-network-layer already does.

Some utility functions were added to help stay DRY and limit the amount
of looping necessary when no maxBatchSize is provided.