### PR TITLE
fix: Don't throw in addition to rejecting a request

### DIFF
--- a/src/relayMutation.js
+++ b/src/relayMutation.js
@@ -27,10 +27,7 @@ export default function mutation(
 
   return fetchWithMiddleware(req)
     .then(({ data }) => relayRequest.resolve({ response: data }))
-    .catch(err => {
-      relayRequest.reject(err);
-      throw err;
-    });
+    .catch(err => relayRequest.reject(err));
 }
 
 function hasFiles(relayRequest: RelayClassicRequest): boolean {

--- a/src/relayQueries.js
+++ b/src/relayQueries.js
@@ -31,10 +31,7 @@ export default function queries(
 
       return fetchWithMiddleware(req)
         .then(({ data }) => relayRequest.resolve({ response: data }))
-        .catch(err => {
-          relayRequest.reject(err);
-          throw err;
-        });
+        .catch(err => relayRequest.reject(err));
     })
   );
 }


### PR DESCRIPTION
I'm seeing an unnecessary error thrown because `react-relay` is chaining a `.catch((err) => setTimeout(() => throw err))` onto `sendQueries`.

Does this package need to throw an error after catching it and calling `relayRequest.reject(err)`?  I saw it was changed in the following commit: https://github.com/relay-tools/react-relay-network-layer/commit/1c0f91b371dc3a1dcea6b3b52e73889455532ad5#diff-9636d8a952e59a775d9229f4e5d9680fR30.